### PR TITLE
Orchestrate full stack services

### DIFF
--- a/.github/workflows/orchestrate_fullstack.yml
+++ b/.github/workflows/orchestrate_fullstack.yml
@@ -1,0 +1,65 @@
+name: Fullstack Orchestration
+
+on:
+  workflow_dispatch:
+
+jobs:
+  fullstack:
+    runs-on: ubuntu-latest
+    env:
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+      MYSQL_USER: ${{ secrets.MYSQL_USER }}
+      MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install PNPM
+        run: npm install -g pnpm
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Start MySQL
+        run: |
+          docker compose -f database/docker-compose.yml up -d
+          echo "Waiting for MySQL to be ready..."
+          for i in {1..30}; do
+            if docker exec mysql-server mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" -e "SELECT 1;" > /dev/null 2>&1; then
+              echo "MySQL is ready!"
+              break
+            fi
+            sleep 2
+          done
+          docker cp database/init.sql mysql-server:/tmp/init.sql
+          docker exec mysql-server mysql -uroot -p${MYSQL_ROOT_PASSWORD} ${MYSQL_DATABASE} < /tmp/init.sql
+
+      - name: Build and run backend
+        working-directory: backend
+        run: |
+          mvn clean package
+          nohup mvn spring-boot:run &
+          sleep 40
+          curl --fail http://localhost:8080/api/tickets || echo "Backend not responding"
+
+      - name: Build and start frontend
+        working-directory: frontend
+        run: |
+          pnpm install
+          pnpm run build
+          nohup pnpm run preview -- --port 4173 &
+          sleep 20
+          curl --fail http://localhost:4173 || echo "Frontend not responding"
+
+      - name: Stop services
+        if: always()
+        run: docker compose -f database/docker-compose.yml down


### PR DESCRIPTION
## Summary
- add new workflow `orchestrate_fullstack.yml` to start MySQL, then backend and finally the frontend

## Testing
- `pnpm install`
- `pnpm run build`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6879a5ddf02483229870b04ed4a9b4b5