### PR TITLE
Fix Vite base path for GitHub Pages

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,7 +5,12 @@ import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/',
+  // Set the base path for GitHub Pages deployment
+  // When deploying under a repository subdirectory, Vite needs to know the
+  // correct base path so that asset URLs are resolved properly. GitHub Pages
+  // serves the site from `/GestioneTickets/`, hence we set the base
+  // accordingly. For local development the leading slash works equally well.
+  base: '/GestioneTickets/',
   plugins: [react(),tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set Vite `base` path to `/GestioneTickets/` for GitHub Pages deployment

## Testing
- `pnpm install`
- `pnpm -s build`

------
https://chatgpt.com/codex/tasks/task_e_6880df41cd148322987a84f025ef1b04